### PR TITLE
Rename everything

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# kube-ecrlogin
+# kube-ecr-login
 
-![GitHub Workflow Status](https://img.shields.io/github/workflow/status/levilutz/kube-ecrlogin/Build)
+![GitHub Workflow Status](https://img.shields.io/github/workflow/status/levilutz/kube-ecr-login/Build)
 ![Docker Pulls](https://img.shields.io/docker/pulls/levilutz/kube-ecr-login)
 
 
@@ -12,7 +12,7 @@ Let's say I want to deploy a containerized application of mine to a kubernetes c
 
 Now my cluster needs to be able to pull from those repositories 24/7. Unfortunately, however, a login for ECR is only valid for 12 hours. How do I ensure my cluster can always pull images from the ECR repos? A few 'easy' solutions to this might come to mind at first, but [many of them have shortcomings](DUMB_ALTERNATIVES.md).
 
-So what solution is implemented here? Run a cluster CronJob that pulls new ECR credentials every <12 hours and stores them in a cluster Secret. I chose every 4 hours to be safe, but this can easily be changed in `kube-ecrlogin.yaml`.
+So what solution is implemented here? Run a cluster CronJob that pulls new ECR credentials every <12 hours and stores them in a cluster Secret. I chose every 4 hours to be safe, but this can easily be changed in `kube-ecr-login.yaml`.
 
 ## Usage
 
@@ -28,7 +28,7 @@ So what solution is implemented here? Run a cluster CronJob that pulls new ECR c
   * `AWS_DEFAULT_REGION`: [As documented](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html#cli-configure-quickstart-region)
   * `AWS_ECR_SERVER`: Eg. `12345678901234.dkr.ecr.us-east-1.amazonaws.com`
 2. Prepare your local environment for `kubectl`, through `KUBECONFIG` or however else you choose.
-3. If your cluster has RBAC, run `kubectl apply --overwrite -f deploy/kube-ecrlogin-rbac.yaml`. If not, run `kubectl apply --overwrite -f deploy/kube-ecrlogin.yaml`.
+3. If your cluster has RBAC, run `kubectl apply --overwrite -f deploy/kube-ecr-login-rbac.yaml`. If not, run `kubectl apply --overwrite -f deploy/kube-ecr-login.yaml`.
   * You can check if RBAC is enabled with `kubectl api-versions | grep rbac`. If you get any results along the lines of `rbac.authorization.k8s.io/v1`, your cluster probably has it enabled. 
 4. Add `imagePullSecrets` to the PodSpecs with ECR-stored images, [as described here](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-pod-that-uses-your-secret). 
 

--- a/deploy/kube-ecr-login-rbac.yaml
+++ b/deploy/kube-ecr-login-rbac.yaml
@@ -1,7 +1,34 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-ecr-login
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-ecr-login
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "watch", "list", "create", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-ecr-login
+subjects:
+- kind: ServiceAccount
+  name: kube-ecr-login
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: kube-ecr-login
+  apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: kube-ecrlogin
+  name: kube-ecr-login
 spec:
   schedule: "0 */4 * * *"
   successfulJobsHistoryLimit: 0
@@ -9,6 +36,7 @@ spec:
     spec:
       template:
         spec:
+          serviceAccountName: kube-ecr-login
           containers:
           - name: sidecar
             image: docker.io/levilutz/kube-ecr-login:latest-sidecar
@@ -27,21 +55,21 @@ spec:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
-                  name: kube-ecrlogin-aws
+                  name: kube-ecr-login-aws
                   key: AWS_ACCESS_KEY_ID
             - name: AWS_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: kube-ecrlogin-aws
+                  name: kube-ecr-login-aws
                   key: AWS_SECRET_ACCESS_KEY
             - name: AWS_DEFAULT_REGION
               valueFrom:
                 secretKeyRef:
-                  name: kube-ecrlogin-aws
+                  name: kube-ecr-login-aws
                   key: AWS_DEFAULT_REGION
             - name: AWS_ECR_SERVER
               valueFrom:
                 secretKeyRef:
-                  name: kube-ecrlogin-aws
+                  name: kube-ecr-login-aws
                   key: AWS_ECR_SERVER
           restartPolicy: OnFailure

--- a/deploy/kube-ecr-login.yaml
+++ b/deploy/kube-ecr-login.yaml
@@ -1,34 +1,7 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: kube-ecrlogin
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: kube-ecrlogin
-rules:
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["get", "watch", "list", "create", "delete"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: kube-ecrlogin
-subjects:
-- kind: ServiceAccount
-  name: kube-ecrlogin
-  namespace: default
-roleRef:
-  kind: ClusterRole
-  name: kube-ecrlogin
-  apiGroup: rbac.authorization.k8s.io
----
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: kube-ecrlogin
+  name: kube-ecr-login
 spec:
   schedule: "0 */4 * * *"
   successfulJobsHistoryLimit: 0
@@ -36,7 +9,6 @@ spec:
     spec:
       template:
         spec:
-          serviceAccountName: kube-ecrlogin
           containers:
           - name: sidecar
             image: docker.io/levilutz/kube-ecr-login:latest-sidecar
@@ -55,21 +27,21 @@ spec:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
-                  name: kube-ecrlogin-aws
+                  name: kube-ecr-login-aws
                   key: AWS_ACCESS_KEY_ID
             - name: AWS_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: kube-ecrlogin-aws
+                  name: kube-ecr-login-aws
                   key: AWS_SECRET_ACCESS_KEY
             - name: AWS_DEFAULT_REGION
               valueFrom:
                 secretKeyRef:
-                  name: kube-ecrlogin-aws
+                  name: kube-ecr-login-aws
                   key: AWS_DEFAULT_REGION
             - name: AWS_ECR_SERVER
               valueFrom:
                 secretKeyRef:
-                  name: kube-ecrlogin-aws
+                  name: kube-ecr-login-aws
                   key: AWS_ECR_SERVER
           restartPolicy: OnFailure

--- a/scripts/aws_secret.sh
+++ b/scripts/aws_secret.sh
@@ -12,10 +12,10 @@ if [ $# -ne 4 ]; then
 fi
 
 echo "Trying to delete old secret, if it exists"
-kubectl delete secret kube-ecrlogin-aws || true
+kubectl delete secret kube-ecr-login-aws || true
 
 echo "Creating new secret"
-kubectl create secret generic kube-ecrlogin-aws \
+kubectl create secret generic kube-ecr-login-aws \
     --from-literal="AWS_ACCESS_KEY_ID=$1" \
     --from-literal="AWS_SECRET_ACCESS_KEY=$2" \
     --from-literal="AWS_DEFAULT_REGION=$3" \

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,4 +1,4 @@
-kubectl delete cronjob kube-ecrlogin || true
-kubectl delete serviceaccount kube-ecrlogin || true
-kubectl delete clusterrole kube-ecrlogin || true
-kubectl delete clusterrolebinding kube-ecrlogin || true
+kubectl delete cronjob kube-ecr-login || true
+kubectl delete serviceaccount kube-ecr-login || true
+kubectl delete clusterrole kube-ecr-login || true
+kubectl delete clusterrolebinding kube-ecr-login || true


### PR DESCRIPTION
Work to correct after re-naming the repository from `kube-ecrlogin` to `kube-ecr-login`. 